### PR TITLE
switch rPython to reticulate

### DIFF
--- a/R/RTconvert.R
+++ b/R/RTconvert.R
@@ -105,15 +105,13 @@ RTconvert = function(lines, add=c(), mark.lines=FALSE, filename="")
 
       outadd = c(
         "python.export.all();",
-        "python.exec(c(",
-        "\"from cStringIO import StringIO\",",
-        "\"import sys\",",
+        "python.run(c(",
         "\"old_stdout = sys.stdout\",",
         "\"sys.stdout = mystdout = StringIO()\",",
         paste0(encodeString(lu,quote="\""),","),
         "\"sys.stdout = old_stdout\"))",
-        "cat(python.method.call(\"mystdout\",\"getvalue\"))",
-        "invisible(python.method.call(\"mystdout\",\"close\"))")
+        "cat(py_call(\"mystdout\",\"getvalue\"))",
+        "invisible(py_call(\"mystdout\",\"close\"))")
     } else if (substr(tag,1,1) == "%") {
       if (length(lu) > 1) stop("'%' tag allowed only for one-line expressions");
       outadd = paste("cat(sprintf(",encodeString(tag,quote="\""),",  ", lu, "  ));",sep="");

--- a/R/RTconvert.R
+++ b/R/RTconvert.R
@@ -110,8 +110,8 @@ RTconvert = function(lines, add=c(), mark.lines=FALSE, filename="")
         "\"sys.stdout = mystdout = StringIO()\",",
         paste0(encodeString(lu,quote="\""),","),
         "\"sys.stdout = old_stdout\"))",
-        "cat(py_call(\"mystdout\",\"getvalue\"))",
-        "invisible(py_call(\"mystdout\",\"close\"))")
+        "cat(py_eval(\"mystdout.getvalue()\"))",
+        "invisible(py_eval(\"mystdout.close()\"))")
     } else if (substr(tag,1,1) == "%") {
       if (length(lu) > 1) stop("'%' tag allowed only for one-line expressions");
       outadd = paste("cat(sprintf(",encodeString(tag,quote="\""),",  ", lu, "  ));",sep="");

--- a/R/RTemplate.R
+++ b/R/RTemplate.R
@@ -46,7 +46,7 @@ python.standards = c(
   "for (i__ in ls(parent.frame())) python.myassign(i__,get(i__));",
   "}",
   "python.run(c(",
-  "\"import StringIO\",",
+  "\"from io import StringIO\",",
   "\"import sys\",",
   "\"import json\"))"
 )

--- a/R/RTemplate.R
+++ b/R/RTemplate.R
@@ -29,8 +29,8 @@ RT.standards = c(
 
 python.standards = c(
   "require(rjson,quietly=TRUE,warn.conflicts=FALSE)",
-  "require(RJSONIO,quietly=TRUE,warn.conflicts=FALSE)",
-  "require(rPython,quietly=TRUE,warn.conflicts=FALSE)",
+  "require(reticulate,quietly=TRUE,warn.conflicts=FALSE)",
+  "python.run = function(str) py_run_string(paste(str,collapse=\"\\n\"))",
   "python.export.all = function() {",
     "python.myassign = function (var.name, value)",
   "{",
@@ -40,11 +40,16 @@ python.standards = c(
   "python.command <- c(paste(var.name, \"='\", value, \"'\", sep = \" \"), ",
   "paste(var.name, \"= json.loads(\", var.name, \")\", sep = \"\"))",
   "python.command <- paste(python.command, collapse = \"\\n\")",
-  "python.exec(python.command)",
+  "python.run(python.command)",
   "invisible(NULL)",
   "}",
   "for (i__ in ls(parent.frame())) python.myassign(i__,get(i__));",
-  "}")
+  "}",
+  "python.run(c(",
+  "\"import StringIO\",",
+  "\"import sys\",",
+  "\"import json\"))"
+)
 
 
 #' Main sript for usage of RTemplate as a command-line tool


### PR DESCRIPTION
required py_eval rather than py_call, but works now and compiles the d2q9_pf_pressureEvolution model