### PR TITLE
Add support for RTemplate embedding/sourcing

### DIFF
--- a/R/RTconvert.R
+++ b/R/RTconvert.R
@@ -96,6 +96,8 @@ RTconvert = function(lines, add=c(), mark.lines=FALSE, filename="")
 #        outadd = rep(outadd,each=2)
 #        outadd[seq(1,length(outadd),2)] = RT.linemark(n$start.line:n$end.line, filename)
       }
+    } else if (tag == "RT") {
+      outadd = RTfile(gsub(' ', '', lu));
     } else if (tag == "python") {
       if (! loaded.rpython) {
         output = c(output,python.standards)

--- a/R/RTconvert.R
+++ b/R/RTconvert.R
@@ -47,23 +47,30 @@ RT.linemark = function(i,filename="",reset=FALSE) {
 #'  "Hello",
 #'  "<?R cat('World') ?>"
 #' ))
-RTconvert = function(lines, add=c(), mark.lines=FALSE, filename="")
+RTconvert = function(lines, add=c(), mark.lines=FALSE, filename="", included=FALSE)
 {
   chunks = RTchunks(lines)
 
-  output = c(
-    "# RTemplate genereted code.",
-    "############# RT standard functions ########",
-    "",
-    RT.standards,
-    "",
-    "############# Parameters and settings ######",
-    "",
-    add,
-    "",
-    "############# Code from Rt file ############",
-    ""
-  )
+  if (!included) {
+    output = c(
+      "# RTemplate genereted code.",
+      "############# RT standard functions ########",
+      "",
+      RT.standards,
+      "",
+      "############# Parameters and settings ######",
+      "",
+      add,
+      "",
+      "############# Code from Rt file ############",
+      ""
+    )
+  } else {
+    output = c(
+      "# RTemplate included file",
+      paste("# Filename:  ", filename)
+    )    
+  }
   loaded.rpython = FALSE
   if (mark.lines) output = c(output, RT.linemark(1,filename))
   for (i in 1:nrow(chunks))
@@ -97,7 +104,7 @@ RTconvert = function(lines, add=c(), mark.lines=FALSE, filename="")
 #        outadd[seq(1,length(outadd),2)] = RT.linemark(n$start.line:n$end.line, filename)
       }
     } else if (tag == "RT") {
-      outadd = RTfile(gsub(' ', '', lu));
+      outadd = RTfile(gsub(' ', '', lu), c(), mark.lines, TRUE );
     } else if (tag == "python") {
       if (! loaded.rpython) {
         output = c(output,python.standards)
@@ -131,6 +138,14 @@ RTconvert = function(lines, add=c(), mark.lines=FALSE, filename="")
   }
   outadd = "cat(\"\\n\")"
   output = c(output,outadd)
+
+  if (included) {
+    outadd = c(
+      paste("#END included for filename:  ", filename)
+    )    
+    output = c(output,outadd)
+  }
+
   if (mark.lines) output = c(output,RT.linemark(-1,filename))
   output
 }


### PR DESCRIPTION
This commit ads a tag
```
<?RT path/to/file/wrt/compiler.RT ?>
```
which sources/e,beds files and allows for reuse of RT code

Example:

outer.RT
```
<?R a = 5 ?>
<?RT inner.RT ?>
<?R print(b) ?>
```


inner.RT
```
<?R 
print(a) 
b = 11
?>
```

 RTfile('tests/outer.RT') results in 
```
 [1] "# RTemplate genereted code."                                                                      
[33] "############# Code from Rt file ############"                                                     
[34] ""                                                                                                 
[35] " a = 5 "                                                                                          
[36] "cat( \"\\n\" );"                                                                                  
[37] "cat( \"\" );"                                                                                     
[38] "# RTemplate genereted code."                                                                      
[39] "############# RT standard functions ########"                                                     
[70] "############# Code from Rt file ############"                                                     
[71] ""                                                                                                 
[72] " "                                                                                                
[73] "print(a) "                                                                                        
[74] "b = 11"                                                                                           
[75] ""                                                                                                 
[76] "cat(\"\\n\")"                                                                                     
[77] "cat( \"\\n\" );"                                                                                  
[78] "cat( \"\" );"                                                                                     
[79] " print(b) "                                                                                       
[80] "cat(\"\\n\")"    
```

