### PR TITLE
Fix readlink of non-existing path on mac

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -2,6 +2,8 @@ readlink = function(a) {
   f = pipe(paste("readlink -f",a))
   ret = readLines(f)
   close(f)
+  # for non existing paths on mac
+  if (length(ret) == 0 || ret == "") ret = a
   ret
 }
 


### PR DESCRIPTION
`readlink -f` on Linux for the path that does not exist still returns the file path. On Mac it returns empty paths, and this breaks TCLB compilation. Tested on Macbook Air M2 and Linux

Related to https://github.com/CFD-GO/TCLB/issues/441

FYI @TravisMitchell 